### PR TITLE
Create types for tests, groups, and suites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -97,16 +97,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indent"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
+
+[[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "infra-smoke-test"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "getset",
+ "indent",
+ "indoc",
+ "pretty_assertions",
+ "typed-builder",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -135,6 +204,17 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
@@ -142,6 +222,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444d8748011b93cb168770e8092458cb0f8854f931ff82fdf6ddfbd72a9c933e"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563b3b88238ec95680aef36bdece66896eaa7ce3c0f1b4f39d38fb2435261352"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -155,6 +255,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "windows-sys"
@@ -221,3 +327,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
+getset = "0.1.2"
+indent = "0.1.1"
+typed-builder = "0.18.1"
+
+[dev-dependencies]
+indoc = "2.0.4"
+pretty_assertions = "1.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 
 mod cli;
 mod environment;
+mod test;
 
 #[cfg(test)]
 mod test_utils;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,0 +1,23 @@
+//! Types that represent tests and their results
+
+use std::future::Future;
+
+pub use self::test_group_result::TestGroupResult;
+pub use self::test_result::TestResult;
+pub use self::test_suite_result::TestSuiteResult;
+
+mod test_group;
+mod test_group_result;
+mod test_result;
+mod test_suite;
+mod test_suite_result;
+
+/// A test
+///
+/// A test performs a single check against the Rust project's infrastructure. It returns a result
+/// that indicates whether the check passed or failed. Tests should be idempotent and should not
+/// have side effects.
+pub trait Test {
+    /// Run the test
+    fn run(&self) -> impl Future<Output = TestResult>;
+}

--- a/src/test/test_group.rs
+++ b/src/test/test_group.rs
@@ -1,0 +1,15 @@
+//! A group of tests that belong together
+
+use std::future::Future;
+
+use crate::test::TestGroupResult;
+
+/// A group of tests that belong together
+///
+/// A test group is a collection of tests that are related to each other. For example, a test group
+/// might contain a few tests that together verify a particular feature of the system. The tests are
+/// run together and the results are aggregated to produce a single result for the group.
+pub trait TestGroup {
+    /// Run the tests in this group
+    fn run(&self) -> impl Future<Output = TestGroupResult>;
+}

--- a/src/test/test_group_result.rs
+++ b/src/test/test_group_result.rs
@@ -1,0 +1,138 @@
+//! The result of a group of tests
+
+use std::fmt::{Display, Formatter};
+
+use getset::{CopyGetters, Getters};
+use typed_builder::TypedBuilder;
+
+use crate::test::TestResult;
+
+/// The result of a group of tests
+///
+/// A test group result contains the name of the group and the results of the individual tests in
+/// the group.
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CopyGetters, Getters, TypedBuilder,
+)]
+pub struct TestGroupResult {
+    /// The name of the test group
+    #[getset(get_copy = "pub")]
+    name: &'static str,
+
+    /// The results of the individual tests in the group
+    #[builder(default)]
+    #[getset(get = "pub")]
+    results: Vec<TestResult>,
+}
+
+impl TestGroupResult {
+    /// Check if all the results in the group are successful
+    ///
+    /// A test group is successful if all the tests in the group are successful. This method
+    /// iterates over the individual test results and checks if all of them are successful.
+    pub fn success(&self) -> bool {
+        self.results.iter().all(|result| result.success())
+    }
+}
+
+impl Display for TestGroupResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let emoji = if self.success() { "✅" } else { "❌" };
+        let display = format!("{} {}", emoji, self.name());
+
+        writeln!(f, "{}", display)?;
+
+        for result in &self.results {
+            writeln!(f, "  {}", result)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn success_with_all_successful_tests() {
+        let group_result = TestGroupResult::builder()
+            .name("group")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder().name("test 2").success(true).build(),
+            ])
+            .build();
+
+        assert!(group_result.success());
+    }
+
+    #[test]
+    fn success_with_one_failed_test() {
+        let group_result = TestGroupResult::builder()
+            .name("group")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder().name("test 2").success(false).build(),
+            ])
+            .build();
+
+        assert!(!group_result.success());
+    }
+
+    #[test]
+    fn trait_display_success_without_message() {
+        let test_result = TestResult::builder().name("test").success(true).build();
+        let group_result = TestGroupResult::builder()
+            .name("group")
+            .results(vec![test_result])
+            .build();
+
+        let expected = indoc! {r#"
+            ✅ group
+              ✅ test
+        "#};
+
+        assert_eq!(expected, format!("{}", group_result));
+    }
+
+    #[test]
+    fn trait_display_failure_with_message() {
+        let test_result = TestResult::builder()
+            .name("test")
+            .success(false)
+            .message(Some("message".into()))
+            .build();
+        let group_result = TestGroupResult::builder()
+            .name("group")
+            .results(vec![test_result])
+            .build();
+
+        let expected = indoc! {r#"
+            ❌ group
+              ❌ test message
+        "#};
+
+        assert_eq!(expected, format!("{}", group_result));
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<TestResult>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<TestResult>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<TestResult>();
+    }
+}

--- a/src/test/test_result.rs
+++ b/src/test/test_result.rs
@@ -1,0 +1,84 @@
+//! The result of a test
+
+use std::fmt::{Display, Formatter};
+
+use getset::{CopyGetters, Getters};
+use typed_builder::TypedBuilder;
+
+/// The result of a test
+///
+/// This struct represents the result of a test. It contains the name of the test, whether it was
+/// successful, and an optional message.
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CopyGetters, Getters, TypedBuilder,
+)]
+pub struct TestResult {
+    /// The name of the test
+    #[getset(get_copy = "pub")]
+    name: &'static str,
+
+    /// Whether the test was successful
+    #[getset(get_copy = "pub")]
+    success: bool,
+
+    /// An optional message
+    #[builder(default)]
+    #[getset(get = "pub")]
+    message: Option<String>,
+}
+
+impl Display for TestResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let emoji = if self.success { "✅" } else { "❌" };
+        let mut display = format!("{} {}", emoji, self.name);
+
+        if let Some(message) = &self.message {
+            display.push(' ');
+            display.push_str(message);
+        }
+
+        write!(f, "{}", display)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_display_success_without_message() {
+        let outcome = TestResult::builder().name("name").success(true).build();
+
+        assert_eq!(format!("{}", outcome), "✅ name");
+    }
+
+    #[test]
+    fn trait_display_failure_with_message() {
+        let outcome = TestResult::builder()
+            .name("name")
+            .success(false)
+            .message(Some("message".into()))
+            .build();
+
+        assert_eq!(format!("{}", outcome), "❌ name message");
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<TestResult>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<TestResult>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<TestResult>();
+    }
+}

--- a/src/test/test_suite.rs
+++ b/src/test/test_suite.rs
@@ -1,0 +1,15 @@
+//! A suite of test groups
+
+use std::future::Future;
+
+use crate::test::TestSuiteResult;
+
+/// A suite of test groups
+///
+/// A test suite is a collection of test groups. Each test group is a collection of tests that are
+/// related to each other in some way. The results of the test groups are aggregated to produce the
+/// overall result of the test suite.
+pub trait TestSuite {
+    /// Run the tests in this suite
+    fn run(&self) -> impl Future<Output = TestSuiteResult>;
+}

--- a/src/test/test_suite_result.rs
+++ b/src/test/test_suite_result.rs
@@ -1,0 +1,188 @@
+//! The result of a test suite
+
+use std::fmt::{Display, Formatter};
+
+use getset::{CopyGetters, Getters};
+use indent::indent_all_by;
+use typed_builder::TypedBuilder;
+
+use crate::test::TestGroupResult;
+
+/// The result of a test suite
+///
+/// A test suite is a collection of test groups. Each test group is a collection of tests. The test
+/// suite result contains the results of all the test groups.
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, CopyGetters, Getters, TypedBuilder,
+)]
+pub struct TestSuiteResult {
+    /// The name of the test suite
+    #[getset(get_copy = "pub")]
+    name: &'static str,
+
+    /// The results of the individual test groups in the suite
+    #[builder(default)]
+    #[getset(get = "pub")]
+    results: Vec<TestGroupResult>,
+}
+
+impl TestSuiteResult {
+    /// Check if all the results in the suite are successful
+    ///
+    /// A test suite is successful if all the tests in its groups are successful. This method
+    /// iterates over the individual test results and checks if all of them are successful.
+    fn success(&self) -> bool {
+        self.results.iter().all(|result| result.success())
+    }
+}
+
+impl Display for TestSuiteResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let emoji = if self.success() { "✅" } else { "❌" };
+        let display = format!("{} {}", emoji, self.name());
+
+        writeln!(f, "{}", display)?;
+
+        for result in &self.results {
+            let indented_result = indent_all_by(2, result.to_string());
+            write!(f, "{}", indented_result)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use crate::test::TestResult;
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn success_with_all_successful_tests() {
+        let group_result = TestGroupResult::builder()
+            .name("group")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder().name("test 2").success(true).build(),
+            ])
+            .build();
+
+        let suite_result = TestSuiteResult::builder()
+            .name("suite")
+            .results(vec![group_result])
+            .build();
+
+        assert!(suite_result.success());
+    }
+
+    #[test]
+    fn success_with_one_failed_test() {
+        let successful_group = TestGroupResult::builder()
+            .name("success")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder().name("test 2").success(true).build(),
+            ])
+            .build();
+
+        let failing_group = TestGroupResult::builder()
+            .name("failure")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder().name("test 2").success(false).build(),
+            ])
+            .build();
+
+        let suite_result = TestSuiteResult::builder()
+            .name("suite")
+            .results(vec![successful_group, failing_group])
+            .build();
+
+        assert!(!suite_result.success());
+    }
+
+    #[test]
+    fn trait_display_success_without_message() {
+        let group_result = TestGroupResult::builder()
+            .name("group")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder().name("test 2").success(true).build(),
+            ])
+            .build();
+
+        let suite_result = TestSuiteResult::builder()
+            .name("suite")
+            .results(vec![group_result])
+            .build();
+
+        let expected = indoc! {r#"
+            ✅ suite
+              ✅ group
+                ✅ test 1
+                ✅ test 2
+        "#};
+
+        assert_eq!(expected, format!("{}", suite_result));
+    }
+
+    #[test]
+    fn trait_display_failure_with_message() {
+        let successful_group = TestGroupResult::builder()
+            .name("success")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder().name("test 2").success(true).build(),
+            ])
+            .build();
+
+        let failing_group = TestGroupResult::builder()
+            .name("failure")
+            .results(vec![
+                TestResult::builder().name("test 1").success(true).build(),
+                TestResult::builder()
+                    .name("test 2")
+                    .success(false)
+                    .message(Some("message".into()))
+                    .build(),
+            ])
+            .build();
+
+        let suite_result = TestSuiteResult::builder()
+            .name("suite")
+            .results(vec![successful_group, failing_group])
+            .build();
+
+        let expected = indoc! {r#"
+            ❌ suite
+              ✅ success
+                ✅ test 1
+                ✅ test 2
+              ❌ failure
+                ✅ test 1
+                ❌ test 2 message
+        "#};
+
+        assert_eq!(expected, format!("{}", suite_result));
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<TestResult>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<TestResult>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<TestResult>();
+    }
+}


### PR DESCRIPTION
An initial design of the interface for tests, test groups, and test suites has been created. Test suites organize tests by the service they check, while test groups can be used implement checks for a particular feature or GitHub issue. Tests are performed asynchronously and return a test result.

The return type might be change in the future to handle issues executing a test, e.g. when there are connectivity issues with the network. These errors will make tests fail without necessarily providing any insight into the correct functioning of the service in question.