### PR TITLE
Create test suite for crates.io

### DIFF
--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -1,0 +1,59 @@
+//! Smoke tests for crates.io
+
+use std::fmt::{Display, Formatter};
+
+use crate::test::{TestSuite, TestSuiteResult};
+
+/// Smoke tests for crates.io
+///
+/// This test suite implements the smoke tests for crates.io, mostly importantly its Content
+/// Delivery Network. The tests ensure that prior bugs in the configuration are not reintroduced,
+/// and that CloudFront and Fastly behave the same.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Crates {}
+
+impl Display for Crates {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "crates.io")
+    }
+}
+
+impl TestSuite for Crates {
+    async fn run(&self) -> TestSuiteResult {
+        TestSuiteResult::builder()
+            .name("crates.io")
+            .results(Vec::new())
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let crates = Crates::default();
+
+        assert_eq!("crates.io", crates.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Crates>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Crates>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Crates>();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ mod cli;
 mod environment;
 mod test;
 
+// Test suites
+mod crates;
+
 #[cfg(test)]
 mod test_utils;
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2,6 +2,7 @@
 
 pub use self::test_group_result::TestGroupResult;
 pub use self::test_result::TestResult;
+pub use self::test_suite::TestSuite;
 pub use self::test_suite_result::TestSuiteResult;
 
 mod test_group;


### PR DESCRIPTION
A new test suite has been created for crates.io. The test suite is intended to test the Content Delivery Networks used by crates.io.