### PR TITLE
Refactor asynchronous traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +473,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 name = "infra-smoke-test"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
  "getset",
  "indent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/jdno/infra-smoke-test"
 publish = false
 
 [dependencies]
+async-trait = "0.1.78"
 clap = { version = "4.5.3", features = ["derive"] }
 getset = "0.1.2"
 indent = "0.1.1"

--- a/src/crates/issue_4891/cloudfront_unencoded.rs
+++ b/src/crates/issue_4891/cloudfront_unencoded.rs
@@ -1,5 +1,6 @@
 //! Test CloudFront with an un-encoded URL
 
+use async_trait::async_trait;
 use url::Url;
 
 use crate::test::{Test, TestResult};
@@ -25,6 +26,7 @@ impl<'a> CloudfrontUnencoded<'a> {
     }
 }
 
+#[async_trait]
 impl<'a> Test for CloudfrontUnencoded<'a> {
     async fn run(&self) -> TestResult {
         let url = Url::parse(&format!(

--- a/src/crates/issue_4891/mod.rs
+++ b/src/crates/issue_4891/mod.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::{Display, Formatter};
 
+use async_trait::async_trait;
+
 use crate::crates::issue_4891::cloudfront_unencoded::CloudfrontUnencoded;
 use crate::environment::Environment;
 use crate::test::{Test, TestGroup, TestGroupResult};
@@ -41,6 +43,7 @@ impl Display for Issue4891 {
     }
 }
 
+#[async_trait]
 impl TestGroup for Issue4891 {
     async fn run(&self) -> TestGroupResult {
         let tests = vec![CloudfrontUnencoded::new(&self.config)];

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::{Display, Formatter};
 
+use async_trait::async_trait;
+
 use crate::crates::issue_4891::Issue4891;
 use crate::environment::Environment;
 use crate::test::{TestGroup, TestSuite, TestSuiteResult};
@@ -32,6 +34,7 @@ impl Display for Crates {
     }
 }
 
+#[async_trait]
 impl TestSuite for Crates {
     async fn run(&self) -> TestSuiteResult {
         let groups = [Issue4891::new(self.env)];

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ mod test_utils;
 async fn main() {
     let cli = Cli::parse();
 
-    let tests = vec![Crates::new(cli.env())];
+    let tests: Vec<Box<dyn TestSuite>> = vec![Box::new(Crates::new(cli.env()))];
 
     let mut results: Vec<TestSuiteResult> = Vec::with_capacity(tests.len());
     for test in &tests {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,5 +1,7 @@
 //! Types that represent tests and their results
 
+use async_trait::async_trait;
+
 pub use self::test_group::TestGroup;
 pub use self::test_group_result::TestGroupResult;
 pub use self::test_result::TestResult;
@@ -17,6 +19,7 @@ mod test_suite_result;
 /// A test performs a single check against the Rust project's infrastructure. It returns a result
 /// that indicates whether the check passed or failed. Tests should be idempotent and should not
 /// have side effects.
+#[async_trait]
 pub trait Test {
     /// Run the test
     async fn run(&self) -> TestResult;

--- a/src/test/test_group.rs
+++ b/src/test/test_group.rs
@@ -1,5 +1,7 @@
 //! A group of tests that belong together
 
+use async_trait::async_trait;
+
 use crate::test::TestGroupResult;
 
 /// A group of tests that belong together
@@ -7,6 +9,7 @@ use crate::test::TestGroupResult;
 /// A test group is a collection of tests that are related to each other. For example, a test group
 /// might contain a few tests that together verify a particular feature of the system. The tests are
 /// run together and the results are aggregated to produce a single result for the group.
+#[async_trait]
 pub trait TestGroup {
     /// Run the tests in this group
     async fn run(&self) -> TestGroupResult;

--- a/src/test/test_suite.rs
+++ b/src/test/test_suite.rs
@@ -1,5 +1,7 @@
 //! A suite of test groups
 
+use async_trait::async_trait;
+
 use crate::test::TestSuiteResult;
 
 /// A suite of test groups
@@ -7,6 +9,7 @@ use crate::test::TestSuiteResult;
 /// A test suite is a collection of test groups. Each test group is a collection of tests that are
 /// related to each other in some way. The results of the test groups are aggregated to produce the
 /// overall result of the test suite.
+#[async_trait]
 pub trait TestSuite {
     /// Run the tests in this suite
     async fn run(&self) -> TestSuiteResult;


### PR DESCRIPTION
The asychronous traits for the test suites, test groups, and tests have been refactored. They are now implemented using the `async-trait` crate, which provides object safety for the trait implementations. The native implementation in Rust does not support that (yet), which makes it impossible to collect any of the trait implementations in a list like `Vec<Box<dyn Test>>`.