### PR TITLE
Refactor logic to test a URL

### DIFF
--- a/src/crates/issue_4891/cloudfront_encoded.rs
+++ b/src/crates/issue_4891/cloudfront_encoded.rs
@@ -1,10 +1,12 @@
 //! Test CloudFront with an encoded URL
 
 use async_trait::async_trait;
+use reqwest::StatusCode;
 
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
+use super::request_url_and_expect_status;
 
 /// The name of the test
 const NAME: &str = "CloudFront encoded";
@@ -37,29 +39,7 @@ impl<'a> Test for CloudfrontEncoded<'a> {
         )
         .replace('+', "%2B");
 
-        let response = match reqwest::get(url).await {
-            Ok(response) => response,
-            Err(error) => {
-                return TestResult::builder()
-                    .name(NAME)
-                    .success(false)
-                    .message(Some(error.to_string()))
-                    .build()
-            }
-        };
-
-        if response.status().is_success() {
-            TestResult::builder().name(NAME).success(true).build()
-        } else {
-            TestResult::builder()
-                .name(NAME)
-                .success(false)
-                .message(Some(format!(
-                    "Expected HTTP 200 OK, got HTTP {}",
-                    response.status()
-                )))
-                .build()
-        }
+        request_url_and_expect_status(NAME, &url, StatusCode::OK).await
     }
 }
 

--- a/src/crates/issue_4891/cloudfront_space.rs
+++ b/src/crates/issue_4891/cloudfront_space.rs
@@ -1,10 +1,12 @@
 //! Test CloudFront with a URL including a space character
 
 use async_trait::async_trait;
+use reqwest::StatusCode;
 
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
+use super::request_url_and_expect_status;
 
 /// The name of the test
 const NAME: &str = "CloudFront with space";
@@ -37,29 +39,7 @@ impl<'a> Test for CloudfrontSpace<'a> {
         )
         .replace('+', " ");
 
-        let response = match reqwest::get(url).await {
-            Ok(response) => response,
-            Err(error) => {
-                return TestResult::builder()
-                    .name(NAME)
-                    .success(false)
-                    .message(Some(error.to_string()))
-                    .build()
-            }
-        };
-
-        if response.status() == 403 {
-            TestResult::builder().name(NAME).success(true).build()
-        } else {
-            TestResult::builder()
-                .name(NAME)
-                .success(false)
-                .message(Some(format!(
-                    "Expected HTTP 403 Forbidden, got HTTP {}",
-                    response.status()
-                )))
-                .build()
-        }
+        request_url_and_expect_status(NAME, &url, StatusCode::FORBIDDEN).await
     }
 }
 

--- a/src/crates/issue_4891/cloudfront_unencoded.rs
+++ b/src/crates/issue_4891/cloudfront_unencoded.rs
@@ -1,10 +1,12 @@
 //! Test CloudFront with an un-encoded URL
 
 use async_trait::async_trait;
+use reqwest::StatusCode;
 
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
+use super::request_url_and_expect_status;
 
 /// The name of the test
 const NAME: &str = "CloudFront unencoded";
@@ -36,29 +38,7 @@ impl<'a> Test for CloudfrontUnencoded<'a> {
             self.config.version()
         );
 
-        let response = match reqwest::get(url).await {
-            Ok(response) => response,
-            Err(error) => {
-                return TestResult::builder()
-                    .name(NAME)
-                    .success(false)
-                    .message(Some(error.to_string()))
-                    .build()
-            }
-        };
-
-        if response.status().is_success() {
-            TestResult::builder().name(NAME).success(true).build()
-        } else {
-            TestResult::builder()
-                .name(NAME)
-                .success(false)
-                .message(Some(format!(
-                    "Expected HTTP 200 OK, got HTTP {}",
-                    response.status()
-                )))
-                .build()
-        }
+        request_url_and_expect_status(NAME, &url, StatusCode::OK).await
     }
 }
 


### PR DESCRIPTION
The different tests for the CloudFront CDN implement exactly the same logic. To make maintenance easier, the code has been moved into the parent module as a function that can be reused by each test.