### PR TITLE
Refactor setup for tests

### DIFF
--- a/src/crates/issue_4891/cloudfront_encoded.rs
+++ b/src/crates/issue_4891/cloudfront_encoded.rs
@@ -45,38 +45,22 @@ impl<'a> Test for CloudfrontEncoded<'a> {
 
 #[cfg(test)]
 mod tests {
-    use mockito::ServerGuard;
-
+    use crate::crates::issue_4891::tests::setup;
     use crate::test_utils::*;
 
     use super::*;
 
     const KRATE: &str = "rust-cratesio-4891";
-    const VERSION: &str = "0.1.0+1";
-
-    async fn setup() -> (ServerGuard, Config) {
-        let server = mockito::Server::new_async().await;
-
-        let config = Config::builder()
-            .krate(KRATE.into())
-            .version(VERSION.into())
-            .cloudfront_url(server.url())
-            .fastly_url(String::new())
-            .build();
-
-        (server, config)
-    }
+    const VERSION: &str = "0.1.0%2B1";
 
     #[tokio::test]
     async fn succeeds_with_http_200_response() {
-        let (mut server, config) = setup().await;
-
-        let encoded_version = VERSION.replace('+', "%2B");
+        let (mut server, config) = setup(KRATE, VERSION).await;
 
         let mock = server
             .mock(
                 "GET",
-                format!("/crates/{KRATE}/{KRATE}-{encoded_version}.crate").as_str(),
+                format!("/crates/{KRATE}/{KRATE}-{VERSION}.crate").as_str(),
             )
             .with_status(200)
             .create();
@@ -91,14 +75,12 @@ mod tests {
 
     #[tokio::test]
     async fn fails_with_other_http_responses() {
-        let (mut server, config) = setup().await;
-
-        let encoded_version = VERSION.replace('+', "%2B");
+        let (mut server, config) = setup(KRATE, VERSION).await;
 
         let mock = server
             .mock(
                 "GET",
-                format!("/crates/{KRATE}/{KRATE}-{encoded_version}.crate").as_str(),
+                format!("/crates/{KRATE}/{KRATE}-{VERSION}.crate").as_str(),
             )
             .with_status(403)
             .create();

--- a/src/crates/issue_4891/cloudfront_space.rs
+++ b/src/crates/issue_4891/cloudfront_space.rs
@@ -45,33 +45,19 @@ impl<'a> Test for CloudfrontSpace<'a> {
 
 #[cfg(test)]
 mod tests {
-    use mockito::ServerGuard;
-
+    use crate::crates::issue_4891::tests::setup;
     use crate::test_utils::*;
 
     use super::*;
 
     const KRATE: &str = "rust-cratesio-4891";
-    const VERSION: &str = "0.1.0+1";
-
-    async fn setup() -> (ServerGuard, Config) {
-        let server = mockito::Server::new_async().await;
-
-        let config = Config::builder()
-            .krate(KRATE.into())
-            .version(VERSION.into())
-            .cloudfront_url(server.url())
-            .fastly_url(String::new())
-            .build();
-
-        (server, config)
-    }
+    const VERSION: &str = "0.1.0 1";
 
     #[tokio::test]
     async fn succeeds_with_http_403_response() {
-        let (mut server, config) = setup().await;
+        let (mut server, config) = setup(KRATE, VERSION).await;
 
-        let encoded_version = VERSION.replace('+', "%20");
+        let encoded_version = VERSION.replace(' ', "%20");
 
         let mock = server
             .mock(
@@ -91,9 +77,9 @@ mod tests {
 
     #[tokio::test]
     async fn fails_with_other_http_responses() {
-        let (mut server, config) = setup().await;
+        let (mut server, config) = setup(KRATE, VERSION).await;
 
-        let encoded_version = VERSION.replace('+', "%20");
+        let encoded_version = VERSION.replace(' ', "%20");
 
         let mock = server
             .mock(

--- a/src/crates/issue_4891/cloudfront_unencoded.rs
+++ b/src/crates/issue_4891/cloudfront_unencoded.rs
@@ -44,8 +44,7 @@ impl<'a> Test for CloudfrontUnencoded<'a> {
 
 #[cfg(test)]
 mod tests {
-    use mockito::ServerGuard;
-
+    use crate::crates::issue_4891::tests::setup;
     use crate::test_utils::*;
 
     use super::*;
@@ -53,22 +52,9 @@ mod tests {
     const KRATE: &str = "rust-cratesio-4891";
     const VERSION: &str = "0.1.0+1";
 
-    async fn setup() -> (ServerGuard, Config) {
-        let server = mockito::Server::new_async().await;
-
-        let config = Config::builder()
-            .krate(KRATE.into())
-            .version(VERSION.into())
-            .cloudfront_url(server.url())
-            .fastly_url(String::new())
-            .build();
-
-        (server, config)
-    }
-
     #[tokio::test]
     async fn succeeds_with_http_200_response() {
-        let (mut server, config) = setup().await;
+        let (mut server, config) = setup(KRATE, VERSION).await;
 
         let mock = server
             .mock(
@@ -88,7 +74,7 @@ mod tests {
 
     #[tokio::test]
     async fn fails_with_other_http_responses() {
-        let (mut server, config) = setup().await;
+        let (mut server, config) = setup(KRATE, VERSION).await;
 
         let mock = server
             .mock(

--- a/src/crates/issue_4891/mod.rs
+++ b/src/crates/issue_4891/mod.rs
@@ -107,11 +107,25 @@ async fn request_url_and_expect_status(
 
 #[cfg(test)]
 mod tests {
+    use mockito::ServerGuard;
     use pretty_assertions::assert_eq;
 
     use crate::test_utils::*;
 
     use super::*;
+
+    pub async fn setup(krate: &'static str, version: &'static str) -> (ServerGuard, Config) {
+        let server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .krate(krate.into())
+            .version(version.into())
+            .cloudfront_url(server.url())
+            .fastly_url(String::new())
+            .build();
+
+        (server, config)
+    }
 
     #[test]
     fn trait_display() {


### PR DESCRIPTION
The tests for the CloudFront CDN all use the same setup code. The setup function has been moved into the parent module so that it can be shared by all tests.