### PR TITLE
Copy & paste tests for Fastly

### DIFF
--- a/src/crates/issue_4891/fastly_encoded.rs
+++ b/src/crates/issue_4891/fastly_encoded.rs
@@ -1,0 +1,110 @@
+//! Test Fastly with an encoded URL
+
+use async_trait::async_trait;
+use reqwest::StatusCode;
+
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+use super::request_url_and_expect_status;
+
+/// The name of the test
+const NAME: &str = "Fastly encoded";
+
+/// Test Fastly with an encoded URL
+///
+/// This test request a URL with an encoded `+` character from Fastly. The test expects the CDN to
+/// return an HTTP 200 OK response.
+pub struct FastlyEncoded<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> FastlyEncoded<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for FastlyEncoded<'a> {
+    async fn run(&self) -> TestResult {
+        let url = format!(
+            "{}/crates/{}/{}-{}.crate",
+            self.config.fastly_url(),
+            self.config.krate(),
+            self.config.krate(),
+            self.config.version()
+        )
+        .replace('+', "%2B");
+
+        request_url_and_expect_status(NAME, &url, StatusCode::OK).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::crates::issue_4891::tests::setup;
+    use crate::test_utils::*;
+
+    use super::*;
+
+    const KRATE: &str = "rust-cratesio-4891";
+    const VERSION: &str = "0.1.0%2B1";
+
+    #[tokio::test]
+    async fn succeeds_with_http_200_response() {
+        let (mut server, config) = setup(KRATE, VERSION).await;
+
+        let mock = server
+            .mock(
+                "GET",
+                format!("/crates/{KRATE}/{KRATE}-{VERSION}.crate").as_str(),
+            )
+            .with_status(200)
+            .create();
+
+        let result = FastlyEncoded::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_with_other_http_responses() {
+        let (mut server, config) = setup(KRATE, VERSION).await;
+
+        let mock = server
+            .mock(
+                "GET",
+                format!("/crates/{KRATE}/{KRATE}-{VERSION}.crate").as_str(),
+            )
+            .with_status(403)
+            .create();
+
+        let result = FastlyEncoded::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<FastlyEncoded>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<FastlyEncoded>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<FastlyEncoded>();
+    }
+}

--- a/src/crates/issue_4891/fastly_space.rs
+++ b/src/crates/issue_4891/fastly_space.rs
@@ -1,0 +1,114 @@
+//! Test Fastly with a URL including a space character
+
+use async_trait::async_trait;
+use reqwest::StatusCode;
+
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+use super::request_url_and_expect_status;
+
+/// The name of the test
+const NAME: &str = "Fastly with space";
+
+/// Test Fastly with a URL including a space character
+///
+/// This test request a URL with a space character from Fastly. The test expects the CDN to return
+/// an HTTP 403 Forbidden response.
+pub struct FastlySpace<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> FastlySpace<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for FastlySpace<'a> {
+    async fn run(&self) -> TestResult {
+        let url = format!(
+            "{}/crates/{}/{}-{}.crate",
+            self.config.fastly_url(),
+            self.config.krate(),
+            self.config.krate(),
+            self.config.version()
+        )
+        .replace('+', " ");
+
+        request_url_and_expect_status(NAME, &url, StatusCode::FORBIDDEN).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::crates::issue_4891::tests::setup;
+    use crate::test_utils::*;
+
+    use super::*;
+
+    const KRATE: &str = "rust-cratesio-4891";
+    const VERSION: &str = "0.1.0 1";
+
+    #[tokio::test]
+    async fn succeeds_with_http_403_response() {
+        let (mut server, config) = setup(KRATE, VERSION).await;
+
+        let encoded_version = VERSION.replace(' ', "%20");
+
+        let mock = server
+            .mock(
+                "GET",
+                format!("/crates/{KRATE}/{KRATE}-{encoded_version}.crate").as_str(),
+            )
+            .with_status(403)
+            .create();
+
+        let result = FastlySpace::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_with_other_http_responses() {
+        let (mut server, config) = setup(KRATE, VERSION).await;
+
+        let encoded_version = VERSION.replace(' ', "%20");
+
+        let mock = server
+            .mock(
+                "GET",
+                format!("/crates/{KRATE}/{KRATE}-{encoded_version}.crate").as_str(),
+            )
+            .with_status(200)
+            .create();
+
+        let result = FastlySpace::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<FastlySpace>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<FastlySpace>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<FastlySpace>();
+    }
+}

--- a/src/crates/issue_4891/fastly_unencoded.rs
+++ b/src/crates/issue_4891/fastly_unencoded.rs
@@ -1,0 +1,109 @@
+//! Test Fastly with an un-encoded URL
+
+use async_trait::async_trait;
+use reqwest::StatusCode;
+
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+use super::request_url_and_expect_status;
+
+/// The name of the test
+const NAME: &str = "Fastly unencoded";
+
+/// Test Fastly with an un-encoded URL
+///
+/// This test request a URL with an un-encoded `+` character from Fastly. The test expects the CDN
+/// to return an HTTP 200 OK response.
+pub struct FastlyUnencoded<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> FastlyUnencoded<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for FastlyUnencoded<'a> {
+    async fn run(&self) -> TestResult {
+        let url = format!(
+            "{}/crates/{}/{}-{}.crate",
+            self.config.fastly_url(),
+            self.config.krate(),
+            self.config.krate(),
+            self.config.version()
+        );
+
+        request_url_and_expect_status(NAME, &url, StatusCode::OK).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::crates::issue_4891::tests::setup;
+    use crate::test_utils::*;
+
+    use super::*;
+
+    const KRATE: &str = "rust-cratesio-4891";
+    const VERSION: &str = "0.1.0+1";
+
+    #[tokio::test]
+    async fn succeeds_with_http_200_response() {
+        let (mut server, config) = setup(KRATE, VERSION).await;
+
+        let mock = server
+            .mock(
+                "GET",
+                format!("/crates/{KRATE}/{KRATE}-{VERSION}.crate").as_str(),
+            )
+            .with_status(200)
+            .create();
+
+        let result = FastlyUnencoded::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_with_other_http_responses() {
+        let (mut server, config) = setup(KRATE, VERSION).await;
+
+        let mock = server
+            .mock(
+                "GET",
+                format!("/crates/{KRATE}/{KRATE}-{VERSION}.crate").as_str(),
+            )
+            .with_status(403)
+            .create();
+
+        let result = FastlyUnencoded::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<FastlyUnencoded>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<FastlyUnencoded>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<FastlyUnencoded>();
+    }
+}

--- a/src/crates/issue_4891/mod.rs
+++ b/src/crates/issue_4891/mod.rs
@@ -12,11 +12,17 @@ use self::cloudfront_encoded::CloudfrontEncoded;
 use self::cloudfront_space::CloudfrontSpace;
 use self::cloudfront_unencoded::CloudfrontUnencoded;
 use self::config::Config;
+use self::fastly_encoded::FastlyEncoded;
+use self::fastly_space::FastlySpace;
+use self::fastly_unencoded::FastlyUnencoded;
 
 mod cloudfront_encoded;
 mod cloudfront_space;
 mod cloudfront_unencoded;
 mod config;
+mod fastly_encoded;
+mod fastly_space;
+mod fastly_unencoded;
 
 /// The name of the test group
 const NAME: &str = "rust-lang/crates.io#4891";
@@ -55,6 +61,9 @@ impl TestGroup for Issue4891 {
             Box::new(CloudfrontEncoded::new(&self.config)),
             Box::new(CloudfrontUnencoded::new(&self.config)),
             Box::new(CloudfrontSpace::new(&self.config)),
+            Box::new(FastlyEncoded::new(&self.config)),
+            Box::new(FastlyUnencoded::new(&self.config)),
+            Box::new(FastlySpace::new(&self.config)),
         ];
 
         let mut results = Vec::new();
@@ -121,7 +130,7 @@ mod tests {
             .krate(krate.into())
             .version(version.into())
             .cloudfront_url(server.url())
-            .fastly_url(String::new())
+            .fastly_url(server.url())
             .build();
 
         (server, config)


### PR DESCRIPTION
The tests that have been implemented for CloudFront have been copy & pasted to test Fastly as well. This duplicates quite a bit of code, especially in the tests. But optimizing this can be done later.