### PR TITLE
Create helper function to construct crate URLs

### DIFF
--- a/src/crates/crates_4891/cloudfront_encoded.rs
+++ b/src/crates/crates_4891/cloudfront_encoded.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
+use crate::crates::utils::crate_url;
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
@@ -30,12 +31,10 @@ impl<'a> CloudfrontEncoded<'a> {
 #[async_trait]
 impl<'a> Test for CloudfrontEncoded<'a> {
     async fn run(&self) -> TestResult {
-        let url = format!(
-            "{}/crates/{}/{}-{}.crate",
+        let url = crate_url(
             self.config.cloudfront_url(),
             self.config.krate(),
-            self.config.krate(),
-            self.config.version()
+            self.config.version(),
         )
         .replace('+', "%2B");
 

--- a/src/crates/crates_4891/cloudfront_space.rs
+++ b/src/crates/crates_4891/cloudfront_space.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
+use crate::crates::utils::crate_url;
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
@@ -30,12 +31,10 @@ impl<'a> CloudfrontSpace<'a> {
 #[async_trait]
 impl<'a> Test for CloudfrontSpace<'a> {
     async fn run(&self) -> TestResult {
-        let url = format!(
-            "{}/crates/{}/{}-{}.crate",
+        let url = crate_url(
             self.config.cloudfront_url(),
             self.config.krate(),
-            self.config.krate(),
-            self.config.version()
+            self.config.version(),
         )
         .replace('+', " ");
 

--- a/src/crates/crates_4891/cloudfront_unencoded.rs
+++ b/src/crates/crates_4891/cloudfront_unencoded.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
+use crate::crates::utils::crate_url;
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
@@ -30,12 +31,10 @@ impl<'a> CloudfrontUnencoded<'a> {
 #[async_trait]
 impl<'a> Test for CloudfrontUnencoded<'a> {
     async fn run(&self) -> TestResult {
-        let url = format!(
-            "{}/crates/{}/{}-{}.crate",
+        let url = crate_url(
             self.config.cloudfront_url(),
             self.config.krate(),
-            self.config.krate(),
-            self.config.version()
+            self.config.version(),
         );
 
         request_url_and_expect_status(NAME, &url, StatusCode::OK).await

--- a/src/crates/crates_4891/fastly_encoded.rs
+++ b/src/crates/crates_4891/fastly_encoded.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
+use crate::crates::utils::crate_url;
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
@@ -30,12 +31,10 @@ impl<'a> FastlyEncoded<'a> {
 #[async_trait]
 impl<'a> Test for FastlyEncoded<'a> {
     async fn run(&self) -> TestResult {
-        let url = format!(
-            "{}/crates/{}/{}-{}.crate",
+        let url = crate_url(
             self.config.fastly_url(),
             self.config.krate(),
-            self.config.krate(),
-            self.config.version()
+            self.config.version(),
         )
         .replace('+', "%2B");
 

--- a/src/crates/crates_4891/fastly_space.rs
+++ b/src/crates/crates_4891/fastly_space.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
+use crate::crates::utils::crate_url;
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
@@ -30,12 +31,10 @@ impl<'a> FastlySpace<'a> {
 #[async_trait]
 impl<'a> Test for FastlySpace<'a> {
     async fn run(&self) -> TestResult {
-        let url = format!(
-            "{}/crates/{}/{}-{}.crate",
+        let url = crate_url(
             self.config.fastly_url(),
             self.config.krate(),
-            self.config.krate(),
-            self.config.version()
+            self.config.version(),
         )
         .replace('+', " ");
 

--- a/src/crates/crates_4891/fastly_unencoded.rs
+++ b/src/crates/crates_4891/fastly_unencoded.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
+use crate::crates::utils::crate_url;
 use crate::test::{Test, TestResult};
 
 use super::config::Config;
@@ -30,12 +31,10 @@ impl<'a> FastlyUnencoded<'a> {
 #[async_trait]
 impl<'a> Test for FastlyUnencoded<'a> {
     async fn run(&self) -> TestResult {
-        let url = format!(
-            "{}/crates/{}/{}-{}.crate",
+        let url = crate_url(
             self.config.fastly_url(),
             self.config.krate(),
-            self.config.krate(),
-            self.config.version()
+            self.config.version(),
         );
 
         request_url_and_expect_status(NAME, &url, StatusCode::OK).await

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -9,6 +9,7 @@ use crate::environment::Environment;
 use crate::test::{TestGroup, TestSuite, TestSuiteResult};
 
 mod crates_4891;
+mod utils;
 
 /// Smoke tests for crates.io
 ///

--- a/src/crates/utils.rs
+++ b/src/crates/utils.rs
@@ -1,0 +1,40 @@
+//! Utility functions for working with crates
+
+/// Construct the URL for a crate
+///
+/// This function constructs the URL for a crate on crates.io. The URL is constructed using the base
+/// URL for the CDN, the name of the crate, and the version of the crate.
+///
+/// # Example
+///
+/// ```rust
+/// use crates::utils::crate_url;
+///
+/// let base_url = "https://example.com";
+/// let krate = "example";
+/// let version = "1.0.0";
+///
+/// let url = crate_url(base_url, krate, version);
+/// ```
+pub fn crate_url(base_url: &str, krate: &str, version: &str) -> String {
+    format!("{}/crates/{}/{}-{}.crate", base_url, krate, krate, version)
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn crate_url_constructs_correct_url() {
+        let base_url = "https://example.com";
+        let krate = "example";
+        let version = "1.0.0";
+
+        let expected = "https://example.com/crates/example/example-1.0.0.crate";
+        let actual = crate_url(base_url, krate, version);
+
+        assert_eq!(expected, actual);
+    }
+}


### PR DESCRIPTION
Probably all smoke tests for crates.io need to construct the URL for a crate. The logic for this has been moved into a helper function that accepts the base URL, the crate's name, and the version and returns the correct URL.