### PR TITLE
Provide better names for test groups

### DIFF
--- a/src/crates/crates_4891/mod.rs
+++ b/src/crates/crates_4891/mod.rs
@@ -28,7 +28,7 @@ mod fastly_space;
 mod fastly_unencoded;
 
 /// The name of the test group
-const NAME: &str = "rust-lang/crates.io#4891";
+const NAME: &str = "rust-lang/crates.io#4891 - Encoded + character";
 
 /// Encoded URLs with a + sign fail
 ///
@@ -143,7 +143,10 @@ mod tests {
     fn trait_display() {
         let crates_4891 = Crates4891::new(Environment::Staging);
 
-        assert_eq!("rust-lang/crates.io#4891", crates_4891.to_string());
+        assert_eq!(
+            "rust-lang/crates.io#4891 - Encoded + character",
+            crates_4891.to_string()
+        );
     }
 
     #[test]

--- a/src/crates/crates_6164/mod.rs
+++ b/src/crates/crates_6164/mod.rs
@@ -21,7 +21,7 @@ mod config;
 mod fastly;
 
 /// The name of the test group
-const NAME: &str = "rust-lang/crates.io#6164";
+const NAME: &str = "rust-lang/crates.io#6164 - CORS headers";
 
 /// Missing CORS header for downloads
 ///
@@ -142,7 +142,10 @@ mod tests {
     fn trait_display() {
         let crates_6164 = Crates6164::new(Environment::Staging);
 
-        assert_eq!("rust-lang/crates.io#6164", crates_6164.to_string());
+        assert_eq!(
+            "rust-lang/crates.io#6164 - CORS headers",
+            crates_6164.to_string()
+        );
     }
 
     #[test]


### PR DESCRIPTION
The names of the two existing test groups have been expanded to provide more context about the tests themselves.