### PR TITLE
Move assertions into shared module

### DIFF
--- a/src/assertion.rs
+++ b/src/assertion.rs
@@ -1,0 +1,17 @@
+//! Shared assertions to test HTTP responses
+
+use reqwest::Response;
+
+/// Check if a response is a redirect
+pub fn is_redirect(response: &Response) -> bool {
+    response.status().is_redirection()
+}
+
+/// Check if a response redirects to the given URL
+pub fn redirects_to(response: &Response, url: &str) -> bool {
+    response
+        .headers()
+        .get("Location")
+        .and_then(|header| header.to_str().ok())
+        .is_some_and(|location| location == url)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::cli::Cli;
 use crate::crates::Crates;
 use crate::test::{TestSuite, TestSuiteResult};
 
+mod assertion;
 mod cli;
 mod environment;
 mod test;


### PR DESCRIPTION
The existing assertions for redirects are being moved into a shared module to reuse them in an upcoming test suite.