### PR TITLE
Add a test suite for rustup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use clap::Parser;
 
 use crate::cli::Cli;
 use crate::crates::Crates;
+use crate::rustup::Rustup;
 use crate::test::{TestSuite, TestSuiteResult};
 
 mod assertion;
@@ -20,6 +21,7 @@ mod test;
 
 // Test suites
 mod crates;
+mod rustup;
 
 #[cfg(test)]
 mod test_utils;
@@ -28,7 +30,10 @@ mod test_utils;
 async fn main() {
     let cli = Cli::parse();
 
-    let tests: Vec<Box<dyn TestSuite>> = vec![Box::new(Crates::new(cli.env()))];
+    let tests: Vec<Box<dyn TestSuite>> = vec![
+        Box::new(Crates::new(cli.env())),
+        Box::new(Rustup::new(cli.env())),
+    ];
 
     let mut results: Vec<TestSuiteResult> = Vec::with_capacity(tests.len());
     for test in &tests {

--- a/src/rustup/mod.rs
+++ b/src/rustup/mod.rs
@@ -1,0 +1,82 @@
+//! Smoke tests for rustup
+
+use std::fmt::{Display, Formatter};
+
+use async_trait::async_trait;
+
+use crate::environment::Environment;
+use crate::rustup::rustup_sh::RustupSh;
+use crate::test::{TestGroup, TestSuite, TestSuiteResult};
+
+mod rustup_sh;
+
+/// Smoke tests for rustup
+///
+/// This test suite implements the smoke tests for rustup. The tests confirm that the domains of
+/// rustup redirect to the correct locations and that the cache invalidations in the CDNs work.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Rustup {
+    /// The environment to run the tests in
+    env: Environment,
+}
+
+impl Rustup {
+    /// Creates a new instance of the test suite
+    pub fn new(env: Environment) -> Self {
+        Self { env }
+    }
+}
+
+impl Display for Rustup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "rustup")
+    }
+}
+
+#[async_trait]
+impl TestSuite for Rustup {
+    async fn run(&self) -> TestSuiteResult {
+        let groups: Vec<Box<dyn TestGroup>> = vec![Box::new(RustupSh::new(self.env))];
+
+        let mut results = Vec::with_capacity(groups.len());
+        for group in &groups {
+            results.push(group.run().await);
+        }
+
+        TestSuiteResult::builder()
+            .name("rustup")
+            .results(results)
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let rustup = Rustup::default();
+
+        assert_eq!("rustup", rustup.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Rustup>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Rustup>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Rustup>();
+    }
+}

--- a/src/rustup/rustup_sh/cloudfront.rs
+++ b/src/rustup/rustup_sh/cloudfront.rs
@@ -1,0 +1,140 @@
+//! Test that CloudFront redirects `/rustup.sh` to `sh.rustup.rs`
+
+use async_trait::async_trait;
+
+use crate::rustup::rustup_sh::request_rustup_and_expect_redirect;
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+
+/// The name of the test
+const NAME: &str = "CloudFront";
+
+/// Test that CloudFront redirects `/rustup.sh` to `sh.rustup.rs`
+///
+/// The test requests the deprecated path `/rustup.sh` from CloudFront and checks that it is
+/// redirected to `sh.rustup.rs`. The body of the response should contain instructions for the users
+/// who don't follow redirects.
+pub struct CloudFront<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> CloudFront<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for CloudFront<'a> {
+    async fn run(&self) -> TestResult {
+        request_rustup_and_expect_redirect(NAME, self.config.cloudfront_url()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn succeeds_with_redirect_and_body() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .build();
+
+        let mock = server
+            .mock("GET", "/rustup.sh")
+            .with_status(307)
+            .with_header("Location", "https://sh.rustup.rs")
+            .with_body(indoc! {r#"
+                #!/bin/bash
+                echo "The location of rustup.sh has moved."
+                echo "Run the following command to install from the new location:"
+                echo "    curl https://sh.rustup.rs -sSf | sh"
+            "#})
+            .create();
+
+        let result = CloudFront::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert_eq!(&None, result.message());
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_redirect() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .build();
+
+        let mock = server
+            .mock("GET", "/rustup.sh")
+            .with_status(200)
+            .with_body(indoc! {r#"
+                #!/bin/bash
+                echo "The location of rustup.sh has moved."
+                echo "Run the following command to install from the new location:"
+                echo "    curl https://sh.rustup.rs -sSf | sh"
+            "#})
+            .create();
+
+        let result = CloudFront::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_body() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .build();
+
+        let mock = server
+            .mock("GET", "/rustup.sh")
+            .with_status(307)
+            .with_header("Location", "https://sh.rustup.rs")
+            .create();
+
+        let result = CloudFront::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<CloudFront>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<CloudFront>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<CloudFront>();
+    }
+}

--- a/src/rustup/rustup_sh/config.rs
+++ b/src/rustup/rustup_sh/config.rs
@@ -1,0 +1,61 @@
+//! Configuration to test `rustup.sh`
+
+use getset::Getters;
+#[cfg(test)]
+use typed_builder::TypedBuilder;
+
+use crate::environment::Environment;
+
+/// Configuration to test `rustup.sh`
+///
+/// The smoke tests request the deprecated URL from Fastly and CloudFront and check for the correct
+/// response.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Getters)]
+#[cfg_attr(test, derive(TypedBuilder))]
+pub struct Config {
+    /// The URL for the CloudFront CDN
+    #[getset(get = "pub")]
+    cloudfront_url: String,
+
+    /// The URL for the Fastly CDN
+    #[getset(get = "pub")]
+    fastly_url: String,
+}
+
+impl Config {
+    /// Return the configuration for the given environment
+    pub fn for_env(env: Environment) -> Self {
+        match env {
+            Environment::Staging => Self {
+                cloudfront_url: "https://cloudfront-dev-static.rust-lang.org".into(),
+                fastly_url: "https://fastly-dev-static.rust-lang.org".into(),
+            },
+            Environment::Production => Self {
+                cloudfront_url: "https://cloudfront-static.rust-lang.org".into(),
+                fastly_url: "https://fastly-static.rust-lang.org".into(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Config>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Config>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Config>();
+    }
+}

--- a/src/rustup/rustup_sh/fastly.rs
+++ b/src/rustup/rustup_sh/fastly.rs
@@ -1,0 +1,140 @@
+//! Test that Fastly redirects `/rustup.sh` to `sh.rustup.rs`
+
+use async_trait::async_trait;
+
+use crate::rustup::rustup_sh::request_rustup_and_expect_redirect;
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+
+/// The name of the test
+const NAME: &str = "Fastly";
+
+/// Test that Fastly redirects `/rustup.sh` to `sh.rustup.rs`
+///
+/// The test requests the deprecated path `/rustup.sh` from Fastly and checks that it is redirected
+/// to `sh.rustup.rs`. The body of the response should contain instructions for the users who don't
+/// follow redirects.
+pub struct Fastly<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> Fastly<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for Fastly<'a> {
+    async fn run(&self) -> TestResult {
+        request_rustup_and_expect_redirect(NAME, self.config.fastly_url()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn succeeds_with_redirect_and_body() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .build();
+
+        let mock = server
+            .mock("GET", "/rustup.sh")
+            .with_status(307)
+            .with_header("Location", "https://sh.rustup.rs")
+            .with_body(indoc! {r#"
+                #!/bin/bash
+                echo "The location of rustup.sh has moved."
+                echo "Run the following command to install from the new location:"
+                echo "    curl https://sh.rustup.rs -sSf | sh"
+            "#})
+            .create();
+
+        let result = Fastly::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert_eq!(&None, result.message());
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_redirect() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .build();
+
+        let mock = server
+            .mock("GET", "/rustup.sh")
+            .with_status(200)
+            .with_body(indoc! {r#"
+                #!/bin/bash
+                echo "The location of rustup.sh has moved."
+                echo "Run the following command to install from the new location:"
+                echo "    curl https://sh.rustup.rs -sSf | sh"
+            "#})
+            .create();
+
+        let result = Fastly::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_body() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder()
+            .cloudfront_url(server.url())
+            .fastly_url(server.url())
+            .build();
+
+        let mock = server
+            .mock("GET", "/rustup.sh")
+            .with_status(307)
+            .with_header("Location", "https://sh.rustup.rs")
+            .create();
+
+        let result = Fastly::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Fastly>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Fastly>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Fastly>();
+    }
+}

--- a/src/rustup/rustup_sh/mod.rs
+++ b/src/rustup/rustup_sh/mod.rs
@@ -1,0 +1,151 @@
+//! Redirect rustup.sh to sh.rustup.rs
+//!
+//! This module test that the deprecated `/rustup.sh` path is redirected to `sh.rustup.rs`.
+
+use std::fmt::{Display, Formatter};
+
+use async_trait::async_trait;
+use reqwest::redirect::Policy;
+use reqwest::Client;
+
+use crate::assertion::{is_redirect, redirects_to};
+use crate::environment::Environment;
+use crate::test::{Test, TestGroup, TestGroupResult, TestResult};
+
+pub use self::cloudfront::CloudFront;
+pub use self::config::Config;
+pub use self::fastly::Fastly;
+
+mod cloudfront;
+mod config;
+mod fastly;
+
+/// The name of the test group
+const NAME: &str = "rustup.sh";
+
+/// Redirect rustup.sh to sh.rustup.rs
+///
+/// The deprecated `/rustup.sh` path is redirected to `sh.rustup.rs`. The body of the HTTP response
+/// contains further instructions for users who might not be following the redirect.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct RustupSh {
+    /// Configuration for the test group
+    config: Config,
+}
+
+impl RustupSh {
+    /// Create a new instance of the test group
+    pub fn new(env: Environment) -> Self {
+        Self {
+            config: Config::for_env(env),
+        }
+    }
+}
+
+impl Display for RustupSh {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", NAME)
+    }
+}
+
+#[async_trait]
+impl TestGroup for RustupSh {
+    async fn run(&self) -> TestGroupResult {
+        let tests: Vec<Box<dyn Test>> = vec![
+            Box::new(CloudFront::new(&self.config)),
+            Box::new(Fastly::new(&self.config)),
+        ];
+
+        let mut results = Vec::new();
+        for test in tests {
+            results.push(test.run().await);
+        }
+
+        TestGroupResult::builder()
+            .name(NAME)
+            .results(results)
+            .build()
+    }
+}
+
+/// Request `/rustup.sh` and assert the correct response
+///
+/// The path `/rustup.sh` is deprecated and is being redirected to `sh.rustup.rs`. This function
+/// requests the path from the given base URL and asserts that the response is both a redirect and
+/// contains instructions for users who don't follow redirects.
+async fn request_rustup_and_expect_redirect(name: &'static str, base_url: &str) -> TestResult {
+    let test_result = TestResult::builder().name(name).success(false);
+
+    let response = match Client::builder()
+        // Don't follow the redirect, we want to check the redirect location
+        .redirect(Policy::none())
+        .build()
+        .expect("failed to build reqwest client")
+        .get(format!("{}/rustup.sh", base_url))
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            return test_result.message(Some(error.to_string())).build();
+        }
+    };
+
+    let expected_location = "https://sh.rustup.rs";
+
+    if !(is_redirect(&response) && redirects_to(&response, expected_location)) {
+        return test_result
+            .message(Some(format!(
+                "Expected a redirect to {}, got {}",
+                expected_location,
+                response.url().as_str()
+            )))
+            .build();
+    }
+
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            return test_result.message(Some(error.to_string())).build();
+        }
+    };
+
+    if !body.contains("https://sh.rustup.rs") {
+        return test_result
+            .message(Some("Expected body to link to sh.rustup.rs".into()))
+            .build();
+    }
+
+    TestResult::builder().name(name).success(true).build()
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_display() {
+        let rustup_sh = RustupSh::new(Environment::Staging);
+
+        assert_eq!("rustup.sh", rustup_sh.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<RustupSh>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<RustupSh>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<RustupSh>();
+    }
+}


### PR DESCRIPTION
The release distribution contains some logic to redirect a deprecated path for rustup to a new location. This logic as well as the body that gets returned to users who don't follow redirects is now being tested as part of a new test suite.