### PR TITLE
Test new architecture on win.rustup.rs

### DIFF
--- a/src/rustup/win_rustup_rs/aarch64.rs
+++ b/src/rustup/win_rustup_rs/aarch64.rs
@@ -1,0 +1,134 @@
+//! Test `win.rustup.rs/aarch64`
+
+use async_trait::async_trait;
+
+use crate::rustup::win_rustup_rs::request_installer_and_expect_attachment;
+use crate::test::{Test, TestResult};
+
+use super::config::Config;
+
+/// The name of the test
+const NAME: &str = "aarch64";
+
+/// Test that `win.rustup.rs/aarch64` serves the Rustup installer
+///
+/// This test requests the installer from `win.rustup.rs/aarch64` and expects the response to contain
+/// the correct file as an attachment.
+pub struct Aarch64<'a> {
+    /// Configuration for this test
+    config: &'a Config,
+}
+
+impl<'a> Aarch64<'a> {
+    /// Create a new instance of the test
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl<'a> Test for Aarch64<'a> {
+    async fn run(&self) -> TestResult {
+        request_installer_and_expect_attachment(
+            NAME,
+            &format!("{}/aarch64", self.config.cloudfront_url()),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn succeeds_with_http_200_and_attachment() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder().cloudfront_url(server.url()).build();
+
+        let mock = server
+            .mock("HEAD", "/aarch64")
+            .with_status(200)
+            .with_header("Content-Type", "application/x-msdownload")
+            .with_header(
+                "Content-Disposition",
+                r#"attachment; filename="rustup-init.exe""#,
+            )
+            .create();
+
+        let result = Aarch64::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert_eq!(&None, result.message());
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_content_type() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder().cloudfront_url(server.url()).build();
+
+        let mock = server
+            .mock("HEAD", "/aarch64")
+            .with_status(200)
+            .with_header(
+                "Content-Disposition",
+                r#"attachment; filename="rustup-init.exe""#,
+            )
+            .create();
+
+        let result = Aarch64::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        let message = result.message().as_ref().unwrap();
+
+        assert!(message.contains("Content-Type"));
+        assert!(!result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_content_disposition() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder().cloudfront_url(server.url()).build();
+
+        let mock = server
+            .mock("HEAD", "/aarch64")
+            .with_status(200)
+            .with_header("Content-Type", "application/x-msdownload")
+            .create();
+
+        let result = Aarch64::new(&config).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        let message = result.message().as_ref().unwrap();
+
+        assert!(message.contains("Content-Disposition"));
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Aarch64>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Aarch64>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Aarch64>();
+    }
+}

--- a/src/rustup/win_rustup_rs/mod.rs
+++ b/src/rustup/win_rustup_rs/mod.rs
@@ -10,10 +10,12 @@ use reqwest::Client;
 use crate::environment::Environment;
 use crate::test::{Test, TestGroup, TestGroupResult, TestResult};
 
+pub use self::aarch64::Aarch64;
 pub use self::config::Config;
 pub use self::i686::I686;
 pub use self::x86_64::X86_64;
 
+mod aarch64;
 mod config;
 mod i686;
 mod x86_64;
@@ -50,6 +52,7 @@ impl Display for WinRustupRs {
 impl TestGroup for WinRustupRs {
     async fn run(&self) -> TestGroupResult {
         let tests: Vec<Box<dyn Test>> = vec![
+            Box::new(Aarch64::new(&self.config)),
             Box::new(I686::new(&self.config)),
             Box::new(X86_64::new(&self.config)),
         ];


### PR DESCRIPTION
A new architecture was just added to `win.rustup.rs`, which is now also covered by a smoke test.