### PR TITLE
Parallelize test execution

### DIFF
--- a/src/crates/crates_4891/cloudfront_encoded.rs
+++ b/src/crates/crates_4891/cloudfront_encoded.rs
@@ -1,5 +1,7 @@
 //! Test CloudFront with an encoded URL
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
@@ -16,20 +18,20 @@ const NAME: &str = "CloudFront encoded";
 ///
 /// This test request a URL with an encoded `+` character from Cloudfront. The test expects the CDN
 /// to return an HTTP 200 OK response.
-pub struct CloudfrontEncoded<'a> {
+pub struct CloudfrontEncoded {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> CloudfrontEncoded<'a> {
+impl CloudfrontEncoded {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for CloudfrontEncoded<'a> {
+impl Test for CloudfrontEncoded {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.cloudfront_url(),
@@ -64,7 +66,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = CloudfrontEncoded::new(&config).run().await;
+        let result = CloudfrontEncoded::new(Arc::new(config.clone())).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -84,7 +86,7 @@ mod tests {
             .with_status(403)
             .create();
 
-        let result = CloudfrontEncoded::new(&config).run().await;
+        let result = CloudfrontEncoded::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/crates_4891/cloudfront_space.rs
+++ b/src/crates/crates_4891/cloudfront_space.rs
@@ -1,5 +1,7 @@
 //! Test CloudFront with a URL including a space character
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
@@ -16,20 +18,20 @@ const NAME: &str = "CloudFront with space";
 ///
 /// This test request a URL with a space character from Cloudfront. The test expects the CDN to
 /// return an HTTP 403 Forbidden response.
-pub struct CloudfrontSpace<'a> {
+pub struct CloudfrontSpace {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> CloudfrontSpace<'a> {
+impl CloudfrontSpace {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for CloudfrontSpace<'a> {
+impl Test for CloudfrontSpace {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.cloudfront_url(),
@@ -66,7 +68,7 @@ mod tests {
             .with_status(403)
             .create();
 
-        let result = CloudfrontSpace::new(&config).run().await;
+        let result = CloudfrontSpace::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -88,7 +90,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = CloudfrontSpace::new(&config).run().await;
+        let result = CloudfrontSpace::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/crates_4891/cloudfront_unencoded.rs
+++ b/src/crates/crates_4891/cloudfront_unencoded.rs
@@ -1,5 +1,7 @@
 //! Test CloudFront with an un-encoded URL
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
@@ -16,20 +18,20 @@ const NAME: &str = "CloudFront unencoded";
 ///
 /// This test request a URL with an un-encoded `+` character from Cloudfront. The test expects the
 /// CDN to return an HTTP 200 OK response.
-pub struct CloudfrontUnencoded<'a> {
+pub struct CloudfrontUnencoded {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> CloudfrontUnencoded<'a> {
+impl CloudfrontUnencoded {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for CloudfrontUnencoded<'a> {
+impl Test for CloudfrontUnencoded {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.cloudfront_url(),
@@ -63,7 +65,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = CloudfrontUnencoded::new(&config).run().await;
+        let result = CloudfrontUnencoded::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -83,7 +85,7 @@ mod tests {
             .with_status(403)
             .create();
 
-        let result = CloudfrontUnencoded::new(&config).run().await;
+        let result = CloudfrontUnencoded::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/crates_4891/fastly_encoded.rs
+++ b/src/crates/crates_4891/fastly_encoded.rs
@@ -1,5 +1,7 @@
 //! Test Fastly with an encoded URL
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
@@ -16,20 +18,20 @@ const NAME: &str = "Fastly encoded";
 ///
 /// This test request a URL with an encoded `+` character from Fastly. The test expects the CDN to
 /// return an HTTP 200 OK response.
-pub struct FastlyEncoded<'a> {
+pub struct FastlyEncoded {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> FastlyEncoded<'a> {
+impl FastlyEncoded {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for FastlyEncoded<'a> {
+impl Test for FastlyEncoded {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.fastly_url(),
@@ -64,7 +66,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = FastlyEncoded::new(&config).run().await;
+        let result = FastlyEncoded::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -84,7 +86,7 @@ mod tests {
             .with_status(403)
             .create();
 
-        let result = FastlyEncoded::new(&config).run().await;
+        let result = FastlyEncoded::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/crates_4891/fastly_space.rs
+++ b/src/crates/crates_4891/fastly_space.rs
@@ -1,5 +1,7 @@
 //! Test Fastly with a URL including a space character
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
@@ -16,20 +18,20 @@ const NAME: &str = "Fastly with space";
 ///
 /// This test request a URL with a space character from Fastly. The test expects the CDN to return
 /// an HTTP 403 Forbidden response.
-pub struct FastlySpace<'a> {
+pub struct FastlySpace {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> FastlySpace<'a> {
+impl FastlySpace {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for FastlySpace<'a> {
+impl Test for FastlySpace {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.fastly_url(),
@@ -66,7 +68,7 @@ mod tests {
             .with_status(403)
             .create();
 
-        let result = FastlySpace::new(&config).run().await;
+        let result = FastlySpace::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -88,7 +90,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = FastlySpace::new(&config).run().await;
+        let result = FastlySpace::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/crates_4891/fastly_unencoded.rs
+++ b/src/crates/crates_4891/fastly_unencoded.rs
@@ -1,5 +1,7 @@
 //! Test Fastly with an un-encoded URL
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use reqwest::StatusCode;
 
@@ -16,20 +18,20 @@ const NAME: &str = "Fastly unencoded";
 ///
 /// This test request a URL with an un-encoded `+` character from Fastly. The test expects the CDN
 /// to return an HTTP 200 OK response.
-pub struct FastlyUnencoded<'a> {
+pub struct FastlyUnencoded {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> FastlyUnencoded<'a> {
+impl FastlyUnencoded {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for FastlyUnencoded<'a> {
+impl Test for FastlyUnencoded {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.fastly_url(),
@@ -63,7 +65,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = FastlyUnencoded::new(&config).run().await;
+        let result = FastlyUnencoded::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -83,7 +85,7 @@ mod tests {
             .with_status(403)
             .create();
 
-        let result = FastlyUnencoded::new(&config).run().await;
+        let result = FastlyUnencoded::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/crates_6164/cloudfront.rs
+++ b/src/crates/crates_6164/cloudfront.rs
@@ -1,5 +1,7 @@
 //! Test the CORS headers on CloudFront
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::crates::utils::crate_url;
@@ -15,20 +17,20 @@ const NAME: &str = "CloudFront";
 ///
 /// This test requests a crate from CloudFront and expects the response to have the correct CORS
 /// headers.
-pub struct CloudFront<'a> {
+pub struct CloudFront {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> CloudFront<'a> {
+impl CloudFront {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for CloudFront<'a> {
+impl Test for CloudFront {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.cloudfront_url(),
@@ -63,7 +65,7 @@ mod tests {
             .with_header("Access-Control-Allow-Origin", "*")
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -83,7 +85,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/crates_6164/fastly.rs
+++ b/src/crates/crates_6164/fastly.rs
@@ -1,5 +1,7 @@
 //! Test the CORS headers on Fastly
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::crates::utils::crate_url;
@@ -15,20 +17,20 @@ const NAME: &str = "Fastly";
 ///
 /// This test requests a crate from Fastly and expects the response to have the correct CORS
 /// headers.
-pub struct Fastly<'a> {
+pub struct Fastly {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> Fastly<'a> {
+impl Fastly {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for Fastly<'a> {
+impl Test for Fastly {
     async fn run(&self) -> TestResult {
         let url = crate_url(
             self.config.fastly_url(),
@@ -63,7 +65,7 @@ mod tests {
             .with_header("Access-Control-Allow-Origin", "*")
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -83,7 +85,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/crates/db_dump/cloudfront.rs
+++ b/src/crates/db_dump/cloudfront.rs
@@ -1,5 +1,7 @@
 //! Test that CloudFront serves the database dump
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::crates::db_dump::ARTIFACTS;
@@ -14,14 +16,14 @@ const NAME: &str = "CloudFront";
 /// Test that CloudFront serves the database dump
 ///
 /// The database dump cannot be served directly from Fastly, so it is served from CloudFront.
-pub struct CloudFront<'a> {
+pub struct CloudFront {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> CloudFront<'a> {
+impl CloudFront {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 
@@ -60,7 +62,7 @@ impl<'a> CloudFront<'a> {
 }
 
 #[async_trait]
-impl<'a> Test for CloudFront<'a> {
+impl Test for CloudFront {
     async fn run(&self) -> TestResult {
         let mut results = Vec::with_capacity(ARTIFACTS.len());
 
@@ -110,7 +112,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock_tar.assert();
@@ -133,7 +135,7 @@ mod tests {
             .with_status(500)
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock_tar.assert();

--- a/src/crates/db_dump/fastly.rs
+++ b/src/crates/db_dump/fastly.rs
@@ -1,5 +1,7 @@
 //! Test that Fastly redirects to CloudFront
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use reqwest::redirect::Policy;
 
@@ -16,14 +18,14 @@ const NAME: &str = "Fastly";
 /// Test that Fastly redirects to CloudFront
 ///
 /// The database dump cannot be served directly from Fastly, so it should redirect to CloudFront.
-pub struct Fastly<'a> {
+pub struct Fastly {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> Fastly<'a> {
+impl Fastly {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 
@@ -67,7 +69,7 @@ impl<'a> Fastly<'a> {
 }
 
 #[async_trait]
-impl<'a> Test for Fastly<'a> {
+impl Test for Fastly {
     async fn run(&self) -> TestResult {
         let mut results = Vec::with_capacity(ARTIFACTS.len());
 
@@ -111,7 +113,7 @@ mod tests {
             .with_header("Location", "https://cloudfront/db-dump.zip")
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock_tar.assert();
@@ -139,7 +141,7 @@ mod tests {
             .with_status(200)
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock_tar.assert();

--- a/src/crates/db_dump/mod.rs
+++ b/src/crates/db_dump/mod.rs
@@ -4,8 +4,10 @@
 //! CloudFront.
 
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::task::JoinSet;
 
 use crate::environment::Environment;
 use crate::test::{Test, TestGroup, TestGroupResult};
@@ -52,15 +54,18 @@ impl Display for DbDump {
 #[async_trait]
 impl TestGroup for DbDump {
     async fn run(&self) -> TestGroupResult {
+        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(CloudFront::new(&self.config)),
-            Box::new(Fastly::new(&self.config)),
+            Box::new(CloudFront::new(config.clone())),
+            Box::new(Fastly::new(config.clone())),
         ];
 
-        let mut results = Vec::new();
+        let mut js = JoinSet::new();
         for test in tests {
-            results.push(test.run().await);
+            js.spawn(async move { test.run().await });
         }
+
+        let results = js.join_all().await;
 
         TestGroupResult::builder()
             .name(NAME)

--- a/src/releases/list_files/cloudfront.rs
+++ b/src/releases/list_files/cloudfront.rs
@@ -1,5 +1,7 @@
 //! Test that CloudFront lists the files in a release
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::releases::list_files::request_index_and_expect_loading_files;
@@ -14,20 +16,20 @@ const NAME: &str = "CloudFront";
 ///
 /// This module test that requests to the `index.html` in each release folder are rewritten to point
 /// to `list-files.html`.
-pub struct CloudFront<'a> {
+pub struct CloudFront {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> CloudFront<'a> {
+impl CloudFront {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for CloudFront<'a> {
+impl Test for CloudFront {
     async fn run(&self) -> TestResult {
         request_index_and_expect_loading_files(
             NAME,
@@ -64,7 +66,7 @@ mod tests {
             "#})
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -88,7 +90,7 @@ mod tests {
             .with_status(404)
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/releases/list_files/fastly.rs
+++ b/src/releases/list_files/fastly.rs
@@ -1,5 +1,7 @@
 //! Test that Fastly lists the files in a release
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::releases::list_files::request_index_and_expect_loading_files;
@@ -14,20 +16,20 @@ const NAME: &str = "Fastly";
 ///
 /// This module test that requests to the `index.html` in each release folder are rewritten to point
 /// to `list-files.html`.
-pub struct Fastly<'a> {
+pub struct Fastly {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> Fastly<'a> {
+impl Fastly {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for Fastly<'a> {
+impl Test for Fastly {
     async fn run(&self) -> TestResult {
         request_index_and_expect_loading_files(
             NAME,
@@ -63,7 +65,7 @@ mod tests {
             "#})
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -87,7 +89,7 @@ mod tests {
             .with_status(404)
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/releases/list_files/mod.rs
+++ b/src/releases/list_files/mod.rs
@@ -4,8 +4,10 @@
 //! to list-files.html.
 
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use tokio::task::JoinSet;
 
 use crate::environment::Environment;
 use crate::test::{Test, TestGroup, TestGroupResult, TestResult};
@@ -49,15 +51,18 @@ impl Display for ListFiles {
 #[async_trait]
 impl TestGroup for ListFiles {
     async fn run(&self) -> TestGroupResult {
+        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(CloudFront::new(&self.config)),
-            Box::new(Fastly::new(&self.config)),
+            Box::new(CloudFront::new(config.clone())),
+            Box::new(Fastly::new(config.clone())),
         ];
 
-        let mut results = Vec::new();
+        let mut js = JoinSet::new();
         for test in tests {
-            results.push(test.run().await);
+            js.spawn(async move { test.run().await });
         }
+
+        let results = js.join_all().await;
 
         TestGroupResult::builder()
             .name(NAME)

--- a/src/releases/rustup_sh/cloudfront.rs
+++ b/src/releases/rustup_sh/cloudfront.rs
@@ -1,5 +1,7 @@
 //! Test that CloudFront redirects `/rustup.sh` to `sh.rustup.rs`
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::releases::rustup_sh::request_rustup_and_expect_redirect;
@@ -15,20 +17,20 @@ const NAME: &str = "CloudFront";
 /// The test requests the deprecated path `/rustup.sh` from CloudFront and checks that it is
 /// redirected to `sh.rustup.rs`. The body of the response should contain instructions for the users
 /// who don't follow redirects.
-pub struct CloudFront<'a> {
+pub struct CloudFront {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> CloudFront<'a> {
+impl CloudFront {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for CloudFront<'a> {
+impl Test for CloudFront {
     async fn run(&self) -> TestResult {
         request_rustup_and_expect_redirect(NAME, self.config.cloudfront_url()).await
     }
@@ -63,7 +65,7 @@ mod tests {
             "#})
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -92,7 +94,7 @@ mod tests {
             "#})
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -115,7 +117,7 @@ mod tests {
             .with_header("Location", "https://sh.rustup.rs")
             .create();
 
-        let result = CloudFront::new(&config).run().await;
+        let result = CloudFront::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/releases/rustup_sh/fastly.rs
+++ b/src/releases/rustup_sh/fastly.rs
@@ -1,5 +1,7 @@
 //! Test that Fastly redirects `/rustup.sh` to `sh.rustup.rs`
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::releases::rustup_sh::request_rustup_and_expect_redirect;
@@ -15,20 +17,20 @@ const NAME: &str = "Fastly";
 /// The test requests the deprecated path `/rustup.sh` from Fastly and checks that it is redirected
 /// to `sh.rustup.rs`. The body of the response should contain instructions for the users who don't
 /// follow redirects.
-pub struct Fastly<'a> {
+pub struct Fastly {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> Fastly<'a> {
+impl Fastly {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for Fastly<'a> {
+impl Test for Fastly {
     async fn run(&self) -> TestResult {
         request_rustup_and_expect_redirect(NAME, self.config.fastly_url()).await
     }
@@ -63,7 +65,7 @@ mod tests {
             "#})
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -92,7 +94,7 @@ mod tests {
             "#})
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -115,7 +117,7 @@ mod tests {
             .with_header("Location", "https://sh.rustup.rs")
             .create();
 
-        let result = Fastly::new(&config).run().await;
+        let result = Fastly::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/rustup/win_rustup_rs/aarch64.rs
+++ b/src/rustup/win_rustup_rs/aarch64.rs
@@ -1,5 +1,7 @@
 //! Test `win.rustup.rs/aarch64`
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::rustup::win_rustup_rs::request_installer_and_expect_attachment;
@@ -14,20 +16,20 @@ const NAME: &str = "aarch64";
 ///
 /// This test requests the installer from `win.rustup.rs/aarch64` and expects the response to contain
 /// the correct file as an attachment.
-pub struct Aarch64<'a> {
+pub struct Aarch64 {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> Aarch64<'a> {
+impl Aarch64 {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for Aarch64<'a> {
+impl Test for Aarch64 {
     async fn run(&self) -> TestResult {
         request_installer_and_expect_attachment(
             NAME,
@@ -59,7 +61,7 @@ mod tests {
             )
             .create();
 
-        let result = Aarch64::new(&config).run().await;
+        let result = Aarch64::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -83,7 +85,7 @@ mod tests {
             )
             .create();
 
-        let result = Aarch64::new(&config).run().await;
+        let result = Aarch64::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -106,7 +108,7 @@ mod tests {
             .with_header("Content-Type", "application/x-msdownload")
             .create();
 
-        let result = Aarch64::new(&config).run().await;
+        let result = Aarch64::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/rustup/win_rustup_rs/i686.rs
+++ b/src/rustup/win_rustup_rs/i686.rs
@@ -1,5 +1,7 @@
 //! Test `win.rustup.rs/i686`
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::rustup::win_rustup_rs::request_installer_and_expect_attachment;
@@ -14,20 +16,20 @@ const NAME: &str = "i686";
 ///
 /// This test requests the installer from `win.rustup.rs/i686` and expects the response to contain
 /// the correct file as an attachment.
-pub struct I686<'a> {
+pub struct I686 {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> I686<'a> {
+impl I686 {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for I686<'a> {
+impl Test for I686 {
     async fn run(&self) -> TestResult {
         request_installer_and_expect_attachment(
             NAME,
@@ -59,7 +61,7 @@ mod tests {
             )
             .create();
 
-        let result = I686::new(&config).run().await;
+        let result = I686::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -83,7 +85,7 @@ mod tests {
             )
             .create();
 
-        let result = I686::new(&config).run().await;
+        let result = I686::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -106,7 +108,7 @@ mod tests {
             .with_header("Content-Type", "application/x-msdownload")
             .create();
 
-        let result = I686::new(&config).run().await;
+        let result = I686::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/rustup/win_rustup_rs/x86_64.rs
+++ b/src/rustup/win_rustup_rs/x86_64.rs
@@ -1,5 +1,7 @@
 //! Test `win.rustup.rs/x86_64`
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::rustup::win_rustup_rs::request_installer_and_expect_attachment;
@@ -14,20 +16,20 @@ const NAME: &str = "x86_64";
 ///
 /// This test requests the installer from `win.rustup.rs/x86_64` and expects the response to contain
 /// the correct file as an attachment.
-pub struct X86_64<'a> {
+pub struct X86_64 {
     /// Configuration for this test
-    config: &'a Config,
+    config: Arc<Config>,
 }
 
-impl<'a> X86_64<'a> {
+impl X86_64 {
     /// Create a new instance of the test
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 }
 
 #[async_trait]
-impl<'a> Test for X86_64<'a> {
+impl Test for X86_64 {
     async fn run(&self) -> TestResult {
         request_installer_and_expect_attachment(
             NAME,
@@ -59,7 +61,7 @@ mod tests {
             )
             .create();
 
-        let result = X86_64::new(&config).run().await;
+        let result = X86_64::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -83,7 +85,7 @@ mod tests {
             )
             .create();
 
-        let result = X86_64::new(&config).run().await;
+        let result = X86_64::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();
@@ -106,7 +108,7 @@ mod tests {
             .with_header("Content-Type", "application/x-msdownload")
             .create();
 
-        let result = X86_64::new(&config).run().await;
+        let result = X86_64::new(Arc::new(config)).run().await;
 
         // Assert that the mock was called
         mock.assert();

--- a/src/test/test_suite.rs
+++ b/src/test/test_suite.rs
@@ -10,7 +10,7 @@ use crate::test::TestSuiteResult;
 /// related to each other in some way. The results of the test groups are aggregated to produce the
 /// overall result of the test suite.
 #[async_trait]
-pub trait TestSuite {
+pub trait TestSuite: Send {
     /// Run the tests in this suite
     async fn run(&self) -> TestSuiteResult;
 }


### PR DESCRIPTION
Fixes #53,

In essence, on every "level",  I use `JoinSet`s to spawn all tests in the loop without `.await`ing them serially.
I also had to change some `&'a Config` to `Arc<Config>`s for this to work nicely.

After doing some performance tests before and after the change I calculated the following speed-up after running both the baseline and the improved version 50 times.

(numbers in milliseconds)
|      | min | median | max |
| --- | ---    | --- | --- |
| baseline | 2716 | 4117 | 6568 |
| improved | 658 | 698 | 1032 |
