### PR TITLE
Avoid duplicating the configurations

### DIFF
--- a/src/crates/crates_4891/mod.rs
+++ b/src/crates/crates_4891/mod.rs
@@ -41,14 +41,14 @@ const NAME: &str = "rust-lang/crates.io#4891 - Encoded + character";
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Crates4891 {
     /// Configuration for the test group
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl Crates4891 {
     /// Create a new instance of the test group
     pub fn new(env: Environment) -> Self {
         Self {
-            config: Config::for_env(env),
+            config: Arc::new(Config::for_env(env)),
         }
     }
 }
@@ -62,14 +62,13 @@ impl Display for Crates4891 {
 #[async_trait]
 impl TestGroup for Crates4891 {
     async fn run(&self) -> TestGroupResult {
-        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(CloudfrontEncoded::new(config.clone())),
-            Box::new(CloudfrontUnencoded::new(config.clone())),
-            Box::new(CloudfrontSpace::new(config.clone())),
-            Box::new(FastlyEncoded::new(config.clone())),
-            Box::new(FastlyUnencoded::new(config.clone())),
-            Box::new(FastlySpace::new(config.clone())),
+            Box::new(CloudfrontEncoded::new(self.config.clone())),
+            Box::new(CloudfrontUnencoded::new(self.config.clone())),
+            Box::new(CloudfrontSpace::new(self.config.clone())),
+            Box::new(FastlyEncoded::new(self.config.clone())),
+            Box::new(FastlyUnencoded::new(self.config.clone())),
+            Box::new(FastlySpace::new(self.config.clone())),
         ];
 
         let mut js = JoinSet::new();

--- a/src/crates/crates_6164/mod.rs
+++ b/src/crates/crates_6164/mod.rs
@@ -33,14 +33,14 @@ const NAME: &str = "rust-lang/crates.io#6164 - CORS headers";
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct Crates6164 {
     /// Configuration for the test group
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl Crates6164 {
     /// Create a new instance of the test group
     pub fn new(env: Environment) -> Self {
         Self {
-            config: Config::for_env(env),
+            config: Arc::new(Config::for_env(env)),
         }
     }
 }
@@ -54,10 +54,9 @@ impl Display for Crates6164 {
 #[async_trait]
 impl TestGroup for Crates6164 {
     async fn run(&self) -> TestGroupResult {
-        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(CloudFront::new(config.clone())),
-            Box::new(Fastly::new(config.clone())),
+            Box::new(CloudFront::new(self.config.clone())),
+            Box::new(Fastly::new(self.config.clone())),
         ];
 
         let mut js = JoinSet::new();

--- a/src/crates/db_dump/mod.rs
+++ b/src/crates/db_dump/mod.rs
@@ -33,14 +33,14 @@ const ARTIFACTS: [&str; 2] = ["db-dump.tar.gz", "db-dump.zip"];
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct DbDump {
     /// Configuration for the test group
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl DbDump {
     /// Create a new instance of the test group
     pub fn new(env: Environment) -> Self {
         Self {
-            config: Config::for_env(env),
+            config: Arc::new(Config::for_env(env)),
         }
     }
 }
@@ -54,10 +54,9 @@ impl Display for DbDump {
 #[async_trait]
 impl TestGroup for DbDump {
     async fn run(&self) -> TestGroupResult {
-        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(CloudFront::new(config.clone())),
-            Box::new(Fastly::new(config.clone())),
+            Box::new(CloudFront::new(self.config.clone())),
+            Box::new(Fastly::new(self.config.clone())),
         ];
 
         let mut js = JoinSet::new();

--- a/src/releases/list_files/mod.rs
+++ b/src/releases/list_files/mod.rs
@@ -30,14 +30,14 @@ const NAME: &str = "list-files.html";
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct ListFiles {
     /// Configuration for the test group
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl ListFiles {
     /// Create a new instance of the test group
     pub fn new(env: Environment) -> Self {
         Self {
-            config: Config::for_env(env),
+            config: Arc::new(Config::for_env(env)),
         }
     }
 }
@@ -51,10 +51,9 @@ impl Display for ListFiles {
 #[async_trait]
 impl TestGroup for ListFiles {
     async fn run(&self) -> TestGroupResult {
-        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(CloudFront::new(config.clone())),
-            Box::new(Fastly::new(config.clone())),
+            Box::new(CloudFront::new(self.config.clone())),
+            Box::new(Fastly::new(self.config.clone())),
         ];
 
         let mut js = JoinSet::new();

--- a/src/releases/rustup_sh/mod.rs
+++ b/src/releases/rustup_sh/mod.rs
@@ -32,14 +32,14 @@ const NAME: &str = "rustup.sh";
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct RustupSh {
     /// Configuration for the test group
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl RustupSh {
     /// Create a new instance of the test group
     pub fn new(env: Environment) -> Self {
         Self {
-            config: Config::for_env(env),
+            config: Arc::new(Config::for_env(env)),
         }
     }
 }
@@ -53,10 +53,9 @@ impl Display for RustupSh {
 #[async_trait]
 impl TestGroup for RustupSh {
     async fn run(&self) -> TestGroupResult {
-        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(CloudFront::new(config.clone())),
-            Box::new(Fastly::new(config.clone())),
+            Box::new(CloudFront::new(self.config.clone())),
+            Box::new(Fastly::new(self.config.clone())),
         ];
 
         let mut js = JoinSet::new();

--- a/src/rustup/win_rustup_rs/mod.rs
+++ b/src/rustup/win_rustup_rs/mod.rs
@@ -32,14 +32,14 @@ const NAME: &str = "win.rustup.rs";
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct WinRustupRs {
     /// Configuration for the test group
-    config: Config,
+    config: Arc<Config>,
 }
 
 impl WinRustupRs {
     /// Create a new instance of the test group
     pub fn new(env: Environment) -> Self {
         Self {
-            config: Config::for_env(env),
+            config: Arc::new(Config::for_env(env)),
         }
     }
 }
@@ -53,11 +53,10 @@ impl Display for WinRustupRs {
 #[async_trait]
 impl TestGroup for WinRustupRs {
     async fn run(&self) -> TestGroupResult {
-        let config = Arc::new(self.config.clone());
         let tests: Vec<Box<dyn Test>> = vec![
-            Box::new(Aarch64::new(config.clone())),
-            Box::new(I686::new(config.clone())),
-            Box::new(X86_64::new(config.clone())),
+            Box::new(Aarch64::new(self.config.clone())),
+            Box::new(I686::new(self.config.clone())),
+            Box::new(X86_64::new(self.config.clone())),
         ];
 
         let mut js = JoinSet::new();


### PR DESCRIPTION
A slight optimization for the recent work on parallel execution has been noted that avoids cloning the configuration. By wrapping the configurations into an `Arc` when they are initialized, it is easier to share them with tests later.