### PR TITLE
Sort results for deterministic output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,10 @@ async fn main() {
         js.spawn(async move { test.run().await });
     }
 
-    let results = js.join_all().await;
+    let mut results = js.join_all().await;
+
+    // Sort the results so that the output is deterministic
+    results.sort();
 
     for result in &results {
         println!("{result}");

--- a/src/test/test_group_result.rs
+++ b/src/test/test_group_result.rs
@@ -42,7 +42,10 @@ impl Display for TestGroupResult {
 
         writeln!(f, "{}", display)?;
 
-        for result in &self.results {
+        let mut sorted_results = self.results.clone();
+        sorted_results.sort();
+
+        for result in sorted_results {
             writeln!(f, "  {}", result)?;
         }
 

--- a/src/test/test_suite_result.rs
+++ b/src/test/test_suite_result.rs
@@ -43,7 +43,10 @@ impl Display for TestSuiteResult {
 
         writeln!(f, "{}", display)?;
 
-        for result in &self.results {
+        let mut sorted_results = self.results.clone();
+        sorted_results.sort();
+
+        for result in sorted_results {
             let indented_result = indent_all_by(2, result.to_string());
             write!(f, "{}", indented_result)?;
         }
@@ -160,12 +163,12 @@ mod tests {
 
         let expected = indoc! {r#"
             ❌ suite
-              ✅ success
-                ✅ test 1
-                ✅ test 2
               ❌ failure
                 ✅ test 1
                 ❌ test 2 message
+              ✅ success
+                ✅ test 1
+                ✅ test 2
         "#};
 
         assert_eq!(expected, format!("{}", suite_result));


### PR DESCRIPTION
After parallelizing the test execution, the results no longer have a deterministic order. This makes using the test suite and debugging failing tests more difficult.