### PR TITLE
Test doc-router for releases

### DIFF
--- a/src/releases/doc_router/config.rs
+++ b/src/releases/doc_router/config.rs
@@ -1,0 +1,54 @@
+//! Configuration to test the doc-router
+
+use getset::Getters;
+#[cfg(test)]
+use typed_builder::TypedBuilder;
+
+use crate::environment::Environment;
+
+/// Configuration to test the doc-router
+///
+/// The tests for the doc-router call various endpoints and make assertions about the responses.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, Getters)]
+#[cfg_attr(test, derive(TypedBuilder))]
+pub struct Config {
+    /// The URL for the CloudFront CDN
+    #[getset(get = "pub")]
+    cloudfront_url: String,
+}
+
+impl Config {
+    /// Return the configuration for the given environment
+    pub fn for_env(env: Environment) -> Self {
+        match env {
+            Environment::Staging => Self {
+                cloudfront_url: "https://dev-doc.rust-lang.org".into(),
+            },
+            Environment::Production => Self {
+                cloudfront_url: "https://doc.rust-lang.org".into(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Config>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Config>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Config>();
+    }
+}

--- a/src/releases/doc_router/mod.rs
+++ b/src/releases/doc_router/mod.rs
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::environment::Environment;
-use crate::releases::doc_router::redirect_root::RedirectRoot;
 use crate::test::{Test, TestGroup, TestGroupResult};
 
 pub use self::config::Config;
+use self::redirect_minor_versions::RedirectMinorVersions;
+use self::redirect_root::RedirectRoot;
 
 mod config;
+mod redirect_minor_versions;
 mod redirect_root;
 
 /// The name of the test group
@@ -48,7 +50,10 @@ impl Display for DocRouter {
 #[async_trait]
 impl TestGroup for DocRouter {
     async fn run(&self) -> TestGroupResult {
-        let tests: Vec<Box<dyn Test>> = vec![Box::new(RedirectRoot::new(self.config.clone()))];
+        let tests: Vec<Box<dyn Test>> = vec![
+            Box::new(RedirectMinorVersions::new(self.config.clone())),
+            Box::new(RedirectRoot::new(self.config.clone())),
+        ];
 
         let mut results = Vec::new();
         for test in tests {

--- a/src/releases/doc_router/mod.rs
+++ b/src/releases/doc_router/mod.rs
@@ -1,0 +1,63 @@
+//! Serve the documentation for Rust's standard library
+//!
+//! This module tests the so-called "doc-router" that serves the documentation for Rust's standard
+//! library. The documentation is only served through CloudFront.
+
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::environment::Environment;
+use crate::releases::doc_router::redirect_root::RedirectRoot;
+use crate::test::{Test, TestGroup, TestGroupResult};
+
+pub use self::config::Config;
+
+mod config;
+mod redirect_root;
+
+/// The name of the test group
+const NAME: &str = "doc-router";
+
+/// Serve the documentation for Rust's standard library
+///
+/// This module tests the so-called "doc-router" that serves the documentation for Rust's standard
+/// library.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct DocRouter {
+    /// Configuration for the test group
+    config: Arc<Config>,
+}
+
+impl DocRouter {
+    /// Create a new instance of the test group
+    pub fn new(env: Environment) -> Self {
+        Self {
+            config: Arc::new(Config::for_env(env)),
+        }
+    }
+}
+
+impl Display for DocRouter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", NAME)
+    }
+}
+
+#[async_trait]
+impl TestGroup for DocRouter {
+    async fn run(&self) -> TestGroupResult {
+        let tests: Vec<Box<dyn Test>> = vec![Box::new(RedirectRoot::new(self.config.clone()))];
+
+        let mut results = Vec::new();
+        for test in tests {
+            results.push(test.run().await);
+        }
+
+        TestGroupResult::builder()
+            .name(NAME)
+            .results(results)
+            .build()
+    }
+}

--- a/src/releases/doc_router/redirect_minor_versions.rs
+++ b/src/releases/doc_router/redirect_minor_versions.rs
@@ -1,0 +1,149 @@
+//! Redirect requests with only a minor versions
+//!
+//! Users might access the documentation using a minor version in the URL, for example
+//! `/1.65/std/boxed/struct.Box.html`. To avoid returning a HTTP 404 Not Found error for such
+//! requests, the doc-router appends `.0` to the minor version and then redirects the request to
+//! that version.
+
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use reqwest::redirect::Policy;
+
+use crate::assertion::{is_redirect, redirects_to};
+use crate::http_client::custom_http_client;
+use crate::releases::doc_router::Config;
+use crate::test::{Test, TestResult};
+
+/// The name of the test
+const NAME: &str = "Redirect minor versions";
+
+/// Redirect requests with only a minor versions
+///
+/// Users might access the documentation using a minor version in the URL, for example `1.65`. To
+/// avoid returning a HTTP 404 Not Found error for such requests, the doc-router appends `.0` to the
+/// minor version and then redirects the request to that version.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct RedirectMinorVersions {
+    /// Configuration for the test group
+    config: Arc<Config>,
+}
+
+impl RedirectMinorVersions {
+    /// Create a new instance of the test
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+}
+
+impl Display for RedirectMinorVersions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", NAME)
+    }
+}
+
+#[async_trait]
+impl Test for RedirectMinorVersions {
+    async fn run(&self) -> TestResult {
+        let test_result = TestResult::builder().name(NAME).success(false);
+
+        let response = match custom_http_client()
+            // Don't follow the redirect, we want to check the redirect location
+            .redirect(Policy::none())
+            .build()
+            .expect("failed to build reqwest client")
+            .get(format!(
+                "{}/1.65/std/boxed/struct.Box.html",
+                self.config.cloudfront_url()
+            ))
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return test_result.message(Some(error.to_string())).build();
+            }
+        };
+
+        let expected_location = "/1.65.0/std/boxed/struct.Box.html";
+
+        if !(is_redirect(&response) && redirects_to(&response, expected_location)) {
+            let location = response
+                .headers()
+                .get("Location")
+                .and_then(|header| header.to_str().ok())
+                .unwrap_or("<empty location header>");
+
+            return test_result
+                .message(Some(format!(
+                    "Expected a redirect to {}, got {}",
+                    expected_location, location
+                )))
+                .build();
+        }
+
+        TestResult::builder().name(NAME).success(true).build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn succeeds_with_redirect_and_body() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder().cloudfront_url(server.url()).build();
+
+        let mock = server
+            .mock("GET", "/1.65/std/boxed/struct.Box.html")
+            .with_status(302)
+            .with_header("Location", "/1.65.0/std/boxed/struct.Box.html")
+            .create();
+
+        let result = RedirectMinorVersions::new(Arc::new(config)).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        std::assert_eq!(&None, result.message());
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_redirect() {
+        let mut server = mockito::Server::new_async().await;
+        let config = Config::builder().cloudfront_url(server.url()).build();
+
+        let mock = server
+            .mock("GET", "/1.65/std/boxed/struct.Box.html")
+            .with_status(200)
+            .create();
+
+        let result = RedirectMinorVersions::new(Arc::new(config)).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<RedirectMinorVersions>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<RedirectMinorVersions>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<RedirectMinorVersions>();
+    }
+}

--- a/src/releases/doc_router/redirect_root.rs
+++ b/src/releases/doc_router/redirect_root.rs
@@ -1,0 +1,138 @@
+//! Redirect `/` or `index.html` to `https://rust-lang.org/learn`
+//!
+//! The doc router redirects the paths `/` and `index.html` to `https://rust-lang.org/learn`.
+
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use reqwest::redirect::Policy;
+
+use crate::assertion::{is_redirect, redirects_to};
+use crate::http_client::custom_http_client;
+use crate::releases::doc_router::Config;
+use crate::test::{Test, TestResult};
+
+/// The name of the test
+const NAME: &str = "Redirect root path";
+
+/// Redirect `/` or `index.html` to `https://rust-lang.org/learn`
+///
+/// The doc router redirects the paths `/` and `index.html` to `https://rust-lang.org/learn`.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct RedirectRoot {
+    /// Configuration for the test group
+    config: Arc<Config>,
+}
+
+impl RedirectRoot {
+    /// Create a new instance of the test
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+}
+
+impl Display for RedirectRoot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", NAME)
+    }
+}
+
+#[async_trait]
+impl Test for RedirectRoot {
+    async fn run(&self) -> TestResult {
+        let test_result = TestResult::builder().name(NAME).success(false);
+
+        let response = match custom_http_client()
+            // Don't follow the redirect, we want to check the redirect location
+            .redirect(Policy::none())
+            .build()
+            .expect("failed to build reqwest client")
+            .get(format!("{}/", self.config.cloudfront_url()))
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return test_result.message(Some(error.to_string())).build();
+            }
+        };
+
+        let expected_location = "https://www.rust-lang.org/learn";
+
+        if !(is_redirect(&response) && redirects_to(&response, expected_location)) {
+            let location = response
+                .headers()
+                .get("Location")
+                .and_then(|header| header.to_str().ok())
+                .unwrap_or("<empty location header>");
+
+            return test_result
+                .message(Some(format!(
+                    "Expected a redirect to {}, got {}",
+                    expected_location, location
+                )))
+                .build();
+        }
+
+        TestResult::builder().name(NAME).success(true).build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn succeeds_with_redirect_and_body() {
+        let mut server = mockito::Server::new_async().await;
+
+        let config = Config::builder().cloudfront_url(server.url()).build();
+
+        let mock = server
+            .mock("GET", "/")
+            .with_status(302)
+            .with_header("Location", "https://www.rust-lang.org/learn")
+            .create();
+
+        let result = RedirectRoot::new(Arc::new(config)).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        std::assert_eq!(&None, result.message());
+        assert!(result.success());
+    }
+
+    #[tokio::test]
+    async fn fails_without_redirect() {
+        let mut server = mockito::Server::new_async().await;
+        let config = Config::builder().cloudfront_url(server.url()).build();
+
+        let mock = server.mock("GET", "/").with_status(200).create();
+
+        let result = RedirectRoot::new(Arc::new(config)).run().await;
+
+        // Assert that the mock was called
+        mock.assert();
+
+        assert!(!result.success());
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<RedirectRoot>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<RedirectRoot>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<RedirectRoot>();
+    }
+}

--- a/src/releases/mod.rs
+++ b/src/releases/mod.rs
@@ -6,10 +6,12 @@ use async_trait::async_trait;
 use tokio::task::JoinSet;
 
 use crate::environment::Environment;
+use crate::releases::doc_router::DocRouter;
 use crate::releases::list_files::ListFiles;
 use crate::releases::rustup_sh::RustupSh;
 use crate::test::{TestGroup, TestSuite, TestSuiteResult};
 
+mod doc_router;
 mod list_files;
 mod rustup_sh;
 
@@ -40,6 +42,7 @@ impl Display for Releases {
 impl TestSuite for Releases {
     async fn run(&self) -> TestSuiteResult {
         let groups: Vec<Box<dyn TestGroup>> = vec![
+            Box::new(DocRouter::new(self.env)),
             Box::new(ListFiles::new(self.env)),
             Box::new(RustupSh::new(self.env)),
         ];


### PR DESCRIPTION
The [release-distribution](https://github.com/rust-lang/simpleinfra/tree/master/terragrunt/modules/release-distribution) includes a Lambda function that handles requests for `doc.rust-lang.org`. Two tests have been added for this distribution to test functionality that was added in https://github.com/rust-lang/simpleinfra/pull/612.