### PR TITLE
Remove the tj-actions/changed-files action

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -9,37 +9,9 @@ name: JSON
   workflow_dispatch:
 
 jobs:
-  detect-changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-
-    outputs:
-      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: detect-changes
-        uses: tj-actions/changed-files@v46
-        with:
-          files: |
-            .github/workflows/json.yml
-            **/*.json
-
-      - name: Print changed files
-        run: |
-          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
   style:
     name: Check JSON style
     runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -9,37 +9,9 @@ name: Markdown
   workflow_dispatch:
 
 jobs:
-  detect-changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-
-    outputs:
-      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: detect-changes
-        uses: tj-actions/changed-files@v46
-        with:
-          files: |
-            .github/workflows/markdown.yml
-            **/*.md
-
-      - name: Print changed files
-        run: |
-          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
   lint:
     name: Lint Markdown files
     runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Checkout code
@@ -53,9 +25,6 @@ jobs:
   style:
     name: Check Markdown style
     runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,39 +15,9 @@ env:
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
-  detect-changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-
-    outputs:
-      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: detect-changes
-        uses: tj-actions/changed-files@v46
-        with:
-          files: |
-            .github/workflows/rust.yml
-            src/**/*
-            Cargo.toml
-            Cargo.lock
-
-      - name: Print changed files
-        run: |
-          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
   lint:
     name: Lint Rust code
     runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Install Just
@@ -71,9 +41,6 @@ jobs:
     name: Check Rust style
     runs-on: ubuntu-latest
 
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-
     steps:
       - name: Install Just
         run: sudo snap install --edge --classic just
@@ -87,9 +54,6 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Install Just

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -9,38 +9,9 @@ name: YAML
   workflow_dispatch:
 
 jobs:
-  detect-changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-
-    outputs:
-      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: detect-changes
-        uses: tj-actions/changed-files@v46
-        with:
-          files: |
-            .github/workflows/yaml.yml
-            **/*.yaml
-            **/*.yml
-
-      - name: Print changed files
-        run: |
-          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
   lint:
     name: Lint YAML files
     runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Checkout code
@@ -52,9 +23,6 @@ jobs:
   style:
     name: Check YAML style
     runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The [tj-actions/changed-files] action had a security incident recently in which a malicious actor dumped all secrets to the build log (see [tj-actions/changed-files#2463]).

The action has been removed from this repository, since the different checks are so fast that running them conditionally is not really necessary.

[tj-actions/changed-files]: https://github.com/tj-actions/changed-files
[tj-actions/changed-files#2463]: https://github.com/tj-actions/changed-files/issues/2463