### PR TITLE
Explicitly include clippy and rustfmt components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.87.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
We want to explicitly include the clippy and rustfmt components in our toolchain to avoid accidentally breaking continuous integration pipelines that might only install a minimal Rust toolchain.